### PR TITLE
improve installer for running via vagrant

### DIFF
--- a/install-website/run.sh
+++ b/install-website/run.sh
@@ -79,7 +79,7 @@ fi
 asCS="sudo -u ${username}"
 
 # Prepare the apt index; it may be practically non-existent on a fresh VM
-apt-get update
+apt-get update > /dev/null
 
 # Install basic software
 apt-get -y install wget git emacs >> ${setupLogFile}


### PR DESCRIPTION
I've tweaked it to cope better with people who have a fresh VM with no apt-cache, and who are too lazy, as I am, to fill in the .config.sh file (whereupon the original script hangs if you lack mysql-server)
