### PR TITLE
Add new routingengine docs & tests dependencies

### DIFF
--- a/install-website/run.sh
+++ b/install-website/run.sh
@@ -484,7 +484,7 @@ if [ ! -x "${routingEngineConfigFile}" ]; then
 fi
 
 # Compile the C++ module; see: https://github.com/cyclestreets/cyclestreets/wiki/Python-routing---starting-and-monitoring
-sudo apt-get -y install gcc g++ python-dev
+sudo apt-get -y install gcc g++ python-dev make cmake doxygen graphviz
 if [ ! -e ${websitesContentFolder}/routingengine/astar_impl.so ]; then
 	echo "Now building the C++ routing module..."
 	cd "${websitesContentFolder}/routingengine/"


### PR DESCRIPTION
cmake and make are used to build the C++ tests.
doxygen and graphviz are used to generate C++ and Python reference documentation.