### PR TITLE
Import: add requirements for new C++ code to TODO list

### DIFF
--- a/install-import/run.sh
+++ b/install-import/run.sh
@@ -232,6 +232,7 @@ done
 # sudo apt install python-pip
 # sudo pip install --upgrade pip
 # sudo -H pip install networkx
+# sudo apt-get -y install gcc g++ python-dev make cmake
 # download of https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.gz to https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.gz
 # execution of import/graph/buildbridge.sh
 # execution of import/graph/islands_cpp/build.sh

--- a/install-import/run.sh
+++ b/install-import/run.sh
@@ -232,6 +232,9 @@ done
 # sudo apt install python-pip
 # sudo pip install --upgrade pip
 # sudo -H pip install networkx
+# download of https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.gz to https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.gz
+# execution of import/graph/buildbridge.sh
+# execution of import/graph/islands_cpp/build.sh
 #
 # Compile bridge detection using: import/graph/buildbridge.sh
 echo "#	$(date)	NetworkX and bridge detection compilation have not yet been implemented by this installer."


### PR DESCRIPTION
To speed up the calculation of islands, I've added a new C++ source directory to cyclestreets:
/websites/www/content/import/graph/islands_cpp/

In particular, the C++ library boost 1.65.1 is now required, to build the new code.