### PR TITLE
Remove variable that is no longer used

### DIFF
--- a/.config.sh.template
+++ b/.config.sh.template
@@ -76,7 +76,6 @@ blogUsername=
 blogPassword=
 
 ## Working directories
-websitesWwwFolder=/websites/www
 websitesContentFolder=/websites/www/content
 websitesBackupsFolder=/websites/www/backups
 websitesLogsFolder=/websites/www/logs


### PR DESCRIPTION
Now that we are getting libboost from a package, we no longer need the
variable that indicated where to expand it to